### PR TITLE
Playback speed adjustment and timing code rewrite

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -1,5 +1,4 @@
 MAJOR FEATURES
--playback speed adjustment
 -scoring
 -error/success feedback
 -sharps and flats
@@ -8,7 +7,7 @@ MINOR FEATURES
 -mute the track you're learning
 
 CODE IMPROVEMENTS
--clean up the Attachable stuff
+-clean up the Attachable stuff: allow only one listener where appropriate
 -use width = None/height = None in ScreenObject to indicate no preferred width/height
 
 LOW PRIORITY

--- a/main.py
+++ b/main.py
@@ -36,6 +36,8 @@ def parseArgs():
                         help='Channel number in TRACK')
     parser.add_argument('--program', type=int, default=-1,
                         help='Program number in TRACK/CHANNEL')
+    parser.add_argument('--speed', type=float, default=1.0,
+                        help='Multiply tempo by SPEED')
     parser.add_argument('--debug', action='store_true',
                         help='Print debug messages')
     args = parser.parse_args()
@@ -102,7 +104,7 @@ def main(argv):
     midiout = midi.OutputConnection()
     outPorts = midiout.probeMidiPorts()
     midiout.openPort(outPorts[args.out_port])
-    midiplayer = MidiPlayer(midiout, args.song_path)
+    midiplayer = MidiPlayer(midiout, args.song_path, args.speed)
     midiplayer.attach(PlayingSongState)
 
     # TODO: consider moving note sequence and ticks per beat out of

--- a/sequencer/midiplayer.py
+++ b/sequencer/midiplayer.py
@@ -112,11 +112,12 @@ class Sequence(list):
 
 class MidiPlayer(Attachable):
 
-    def __init__(self, midioutConnection, filename):
+    def __init__(self, midioutConnection, filename, tempoMultiplier=1.0):
         super(MidiPlayer, self).__init__()
         self._log = logging.getLogger("keyzer:MidiPlayer")
         self._midiout = midioutConnection
         self._filename = filename
+        self._tempoMultiplier = float(tempoMultiplier)
         self._pattern = midi.read_midifile(filename)
         self._beatsPerMin = _DEFAULT_BEATSPERMIN
         self._ticksPerBeat = self._pattern.resolution
@@ -129,9 +130,9 @@ class MidiPlayer(Attachable):
         super(MidiPlayer, self).attach(objectToAttach)
 
     def onTempoChange(self, beatsPerMinute):
-        self._log.debug("onTempoChange({})".format(beatsPerMinute))
-        self._beatsPerMin = float(beatsPerMinute)
-        self._ticksPerFrame = self.secondsToTicks(self._beatsPerMin, _SECONDS_PER_FRAME)
+        self._log.debug("onTempoChange({}) multiplier {}".format(
+                        beatsPerMinute, self._tempoMultiplier))
+        self._beatsPerMin = self._tempoMultiplier * beatsPerMinute
 
     def play(self):
         self.onTempoChange(_DEFAULT_BEATSPERMIN)


### PR DESCRIPTION
This PR adds a command line argument for playback speed adjustment (`--speed`). The intended use is to play a track slowly when learning it. The argument passed using `--speed` is a tempo multiplier, so `--speed 1` plays back at normal tempo, `--speed 0.5` plays back at half tempo, and `--speed 2` plays back at two times the normal tempo.

As part of this PR, the timing code in sequencer/midiplayer.py is rewritten to make playback speed more accurate (reduces a "tempo drift" effect that caused slow and unsteady playback). See commit b3e6e465 for more details.
